### PR TITLE
Fix Cablenet.from_rhinomesh & Cablenet.from_rhinosurface

### DIFF
--- a/src/compas_fofin/datastructures/cablenet.py
+++ b/src/compas_fofin/datastructures/cablenet.py
@@ -108,7 +108,7 @@ class Cablenet(Mesh):
             An instance of a cable net.
 
         """
-        from compas_rhino.helpers import mesh_from_guid
+        from compas_rhino.geometry._constructors import mesh_from_guid
         return mesh_from_guid(cls, guid)
 
     @classmethod
@@ -132,7 +132,7 @@ class Cablenet(Mesh):
             An instance of a cable net.
 
         """
-        from compas_rhino.helpers import mesh_from_surface_uv
+        from compas_rhino.geometry._constructors import mesh_from_surface_uv
         return mesh_from_surface_uv(cls, guid, density=(u, v))
 
     def get_continuous_edges(self, edge, aligned=False):

--- a/src/compas_fofin/datastructures/cablenet.py
+++ b/src/compas_fofin/datastructures/cablenet.py
@@ -108,8 +108,8 @@ class Cablenet(Mesh):
             An instance of a cable net.
 
         """
-        from compas_rhino.geometry._constructors import mesh_from_guid
-        return mesh_from_guid(cls, guid)
+        from compas_rhino.geometry import RhinoMesh
+        return RhinoMesh.from_guid(guid).to_compas(cls=cls)
 
     @classmethod
     def from_rhinosurface(cls, guid, u=20, v=10):
@@ -132,8 +132,8 @@ class Cablenet(Mesh):
             An instance of a cable net.
 
         """
-        from compas_rhino.geometry._constructors import mesh_from_surface_uv
-        return mesh_from_surface_uv(cls, guid, density=(u, v))
+        from compas_rhino.geometry import RhinoSurface
+        return RhinoSurface.from_guid(guid).uv_to_compas(cls=cls, density=(u, v))
 
     def get_continuous_edges(self, edge, aligned=False):
         """Get the edges forming a continuous line with the selected edge.


### PR DESCRIPTION
`compas_rhino.helpers.mesh_from_guid` and `mesh_from_surface_uv` have been depracted in favor of `compas_rhino.geometry.RhinoMesh.from_guid` and `RhinoSurface.uv_to_compas`.

So far this only a quick fix, I'm guessing `compas_rhino.geometry._constructors` will also be removed. What I can't get to work is getting a `Cablenet` instance from `RhinoMesh.from_guid`. Any suggestions, @brgcode?